### PR TITLE
updating `SESSION_KEY_MAXLENGTH` to allow module to work against SFU CAS' newer `mod_auth_cas`

### DIFF
--- a/django_cas_ng/models.py
+++ b/django_cas_ng/models.py
@@ -10,7 +10,7 @@ from .utils import get_cas_client, get_user_from_session
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
 
 
-SESSION_KEY_MAXLENGTH = 1024
+SESSION_KEY_MAXLENGTH = 512
 
 
 class ProxyError(ValueError):


### PR DESCRIPTION
updating `SESSION_KEY_MAXLENGTH` to be `512` since trying to authenticate against the newer `mod_auth_cas` for SFU CAS results in the following line https://github.com/gregbaker/django-cas-ng/blob/132b2da79f84c1859f168f9dcbbe73cbe0b31be6/django_cas_ng/views.py#L151-L155

Throwing error

```
django.db.utils.DataError: value too long for type character varying(512)
```